### PR TITLE
Rubocop-factory_bot and Performance extensions have been updated to the plugins api

### DIFF
--- a/rubocop.yml
+++ b/rubocop.yml
@@ -1,10 +1,8 @@
 # We borrowed some configuration and started with Rails' Rubocop configuration:
 # https://github.com/rails/rails/blob/main/.rubocop.yml
-require:
+plugins:
   - rubocop-factory_bot
   - rubocop-performance
-
-plugins:
   - rubocop-rails
 
 AllCops:


### PR DESCRIPTION
Rubocop-factory_bot and Performance extensions have been updated to the plugins api

This PR will disable the nag message that we need to move them.