### PR TITLE
Disallow one-line methods and guard assignments

### DIFF
--- a/rubocop.yml
+++ b/rubocop.yml
@@ -42,6 +42,10 @@ Layout/EndAlignment:
 Layout/LineLength:
   Max: 120
 
+Lint/AssignmentInCondition:
+  # Guard conditions should be predicates, not hidden assignments.
+  AllowSafeAssignment: false
+
 Metrics/BlockLength:
   Exclude:
     # Long blocks in config files aren’t really a problem.
@@ -132,6 +136,10 @@ Style/EmptyMethod:
   # Ruby is a language where you don't use semi-colons in general.
   EnforcedStyle: expanded
 
+Style/EndlessMethod:
+  # Prefer regular multi-line method definitions for readability.
+  EnforcedStyle: disallow
+
 Style/FormatString:
   # Prefer writing string formatting as "Some %<foo>s" % { foo: "var" }. With long translation
   # strings it may become less readable by having to wrap _("...") in format().
@@ -149,6 +157,10 @@ Style/IfUnlessModifier:
   # instead of
   #   do_the_things if something
   Enabled: false
+
+Style/SingleLineMethods:
+  # Prefer regular multi-line method definitions, even for tiny bodies.
+  Enabled: true
 
 # Check quotes usage according to lint rule below.
 Style/StringLiterals:


### PR DESCRIPTION
As discused this morning during dev-meeting, here are change to make rubocop be more strict.

## Summary

Disallow assignments in conditionals used as guards by setting Lint/AssignmentInCondition to reject safe assignments.
Disallow both classic single-line method definitions and Ruby endless methods in the shared RuboCop config.

## Validation

Parsed rubocop.yml with Ruby YAML loading and verified the target patterns are flagged with rubocop -c rubocop.yml --stdin.
